### PR TITLE
Add reference to config for outputdim

### DIFF
--- a/ced_model/modeling_ced.py
+++ b/ced_model/modeling_ced.py
@@ -541,7 +541,7 @@ class CedForAudioClassification(CedPreTrainedModel):
             except AttributeError:
                 raise NotImplementedError(f"Loss {self.config.loss} not implemented.")
 
-            labels = nn.functional.one_hot(labels, num_classes=self.outputdim).float()
+            labels = nn.functional.one_hot(labels, num_classes=self.config.outputdim).float()
             loss = loss_fct(logits, labels)
         else:
             loss = None


### PR DESCRIPTION
Since outputdim is not defined in the constructor of CedForAudioClassification class, using self.outputdim will cause an error saying outputdim is not defined. However, outputdim is defined in the config variable and just by using self.config.outputdim, the one_hot function will have access to outputdim and the model will run without an error.